### PR TITLE
Update Elasticsearch dependency so automated install can work

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,7 +1,7 @@
 name: elasticvue
 
 dependencies:
-  - elasticsearch
+  - ddev/ddev-elasticsearch
 
 # list of files and directories listed that are copied into project .ddev directory
 project_files:


### PR DESCRIPTION
In upcoming DDEV version v1.24.8, `ddev add-on get` will try to download dependencies, so the `dependencies` list has to show where the dependencies can come from. Please pull this and make a new release, thanks!